### PR TITLE
roq_derive: add snapshot tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+*.pending-snap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,10 +65,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "insta"
+version = "1.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eab73f58e59ca6526037208f0e98851159ec1633cf17b6cd2e1f2c3fd5d53cc"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -104,6 +146,7 @@ dependencies = [
 name = "roq_derive"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "proc-macro2",
  "quote",
  "roq_core",
@@ -149,6 +192,12 @@ name = "shiba"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46e999d3caafdbe07de20db4c787b3be9d669574ef397aa6efc6b19f7c8eef62"
+
+[[package]]
+name = "similar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 
 [[package]]
 name = "syn"

--- a/roq_derive/Cargo.toml
+++ b/roq_derive/Cargo.toml
@@ -15,3 +15,6 @@ syn = { version = "2.0.58", features = ["full"] }
 uneval = "0.2.4"
 proc-macro2 = "1.0.79"
 
+[dev-dependencies]
+insta = "1.38.0"
+

--- a/roq_derive/src/expr.rs
+++ b/roq_derive/src/expr.rs
@@ -1,0 +1,38 @@
+use roq_core::ast;
+use syn::spanned::Spanned;
+
+pub fn expr_as_v(source: &syn::Expr) -> syn::Result<ast::Expr> {
+    match source {
+        // Match integer literals.
+        syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Int(int),
+            ..
+        }) => Ok(ast::Expr::Nat(int.base10_parse().unwrap())),
+
+        // Match boolean literals.
+        syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Bool(boolean),
+            ..
+        }) => Ok(ast::Expr::Bool(boolean.value)),
+
+        // Match variables.
+        syn::Expr::Path(syn::ExprPath {
+            path: syn::Path { segments, .. },
+            ..
+        }) => match segments.iter().collect::<Vec<_>>().as_slice() {
+            [segment] => {
+                let ident = &segment.ident;
+                Ok(ast::Expr::Var(ident.to_string()))
+            }
+            _ => Err(syn::Error::new(
+                segments.first().unwrap().ident.span(),
+                "expected a single path segment",
+            )),
+        },
+
+        _ => Err(syn::Error::new(
+            source.span(),
+            "expected an integer literal, boolean literal, or a variable",
+        )),
+    }
+}

--- a/roq_derive/src/func.rs
+++ b/roq_derive/src/func.rs
@@ -1,0 +1,102 @@
+use roq_core::ast;
+use syn::spanned::Spanned;
+
+use crate::{expr::expr_as_v, ty::type_as_v};
+
+pub fn fn_as_definition(source: &syn::ItemFn) -> syn::Result<ast::Definition> {
+    let name = source.sig.ident.to_string();
+
+    // Map the return type, which is mandatory.
+    let ret = match &source.sig.output {
+        syn::ReturnType::Default => {
+            return Err(syn::Error::new(
+                source.sig.output.span(),
+                "expected a return type",
+            ))
+        }
+        syn::ReturnType::Type(_, ty) => type_as_v(ty)?,
+    };
+
+    // Map each of the arguments.
+    let mut args = vec![];
+    for arg in &source.sig.inputs {
+        match arg {
+            syn::FnArg::Receiver(_) => {
+                return Err(syn::Error::new(
+                    arg.span(),
+                    "can't generate Coq `Definition` for function which takes `self`",
+                ))
+            }
+
+            syn::FnArg::Typed(pat) => {
+                let name = match &*pat.pat {
+                    syn::Pat::Ident(ident) => ident.ident.to_string(),
+                    _ => {
+                        return Err(syn::Error::new(
+                            pat.pat.span(),
+                            "expected a single identifier, not a pattern, in function argument",
+                        ))
+                    }
+                };
+                let ty = type_as_v(&pat.ty)?;
+                args.push(ast::Binder { name, ty });
+            }
+        }
+    }
+
+    // Make sure the function consists of a single statement.
+    let statement = match source.block.stmts.as_slice() {
+        [stmt] => stmt,
+        [] => {
+            return Err(syn::Error::new(
+                source.block.span(),
+                "expected at least one statement in block",
+            ))
+        }
+
+        // TODO: this is a really dumb restriction.
+        [..] => {
+            return Err(syn::Error::new(
+                source.block.span(),
+                "expected exactly one statement in function body",
+            ))
+        }
+    };
+
+    // Make sure that statement is an expression.
+    let expr: syn::Expr = match statement {
+        syn::Stmt::Expr(expr, _) => expr.clone(),
+        _ => {
+            return Err(syn::Error::new(
+                statement.span(),
+                "expected statement to be an expression",
+            ))
+        }
+    };
+
+    // Parse binary addition to start out.
+    let body = match expr {
+        // Binary addition
+        syn::Expr::Binary(syn::ExprBinary {
+            left,
+            right,
+            op: syn::BinOp::Add(_),
+            ..
+        }) => {
+            let lhs = expr_as_v(&left)?;
+            let rhs = expr_as_v(&right)?;
+            ast::Expr::Apply {
+                func: "plus".into(),
+                args: vec![lhs, rhs],
+            }
+        }
+        _ => panic!("unsupported expression"),
+    };
+
+    Ok(ast::Definition {
+        name,
+        args,
+        ret,
+        body,
+    })
+}

--- a/roq_derive/src/lib.rs
+++ b/roq_derive/src/lib.rs
@@ -1,8 +1,10 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use roq_core::ast;
-use syn::spanned::Spanned;
+
+mod expr;
+mod func;
+mod ty;
 
 /// Generate a Coq `Definition` statement from a Rust function.
 #[proc_macro_attribute]
@@ -14,7 +16,7 @@ pub fn definition(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     // Convert the function to a Coq `Definition` AST node.
-    let definition = match fn_as_definition(&input) {
+    let definition = match func::fn_as_definition(&input) {
         Ok(definition) => definition,
         Err(err) => return TokenStream::from(err.to_compile_error()),
     };
@@ -46,162 +48,4 @@ pub fn definition(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
     })
-}
-
-fn fn_as_definition(source: &syn::ItemFn) -> syn::Result<ast::Definition> {
-    let name = source.sig.ident.to_string();
-
-    // Map the return type, which is mandatory.
-    let ret = match &source.sig.output {
-        syn::ReturnType::Default => {
-            return Err(syn::Error::new(
-                source.sig.output.span(),
-                "expected a return type",
-            ))
-        }
-        syn::ReturnType::Type(_, ty) => type_as_v(ty)?,
-    };
-
-    // Map each of the arguments.
-    let mut args = vec![];
-    for arg in &source.sig.inputs {
-        match arg {
-            syn::FnArg::Receiver(_) => {
-                return Err(syn::Error::new(
-                    arg.span(),
-                    "can't generate Coq `Definition` for function which takes `self`",
-                ))
-            }
-
-            syn::FnArg::Typed(pat) => {
-                let name = match &*pat.pat {
-                    syn::Pat::Ident(ident) => ident.ident.to_string(),
-                    _ => {
-                        return Err(syn::Error::new(
-                            pat.pat.span(),
-                            "expected a single identifier, not a pattern, in function argument",
-                        ))
-                    }
-                };
-                let ty = type_as_v(&pat.ty)?;
-                args.push(ast::Binder { name, ty });
-            }
-        }
-    }
-
-    // Make sure the function consists of a single statement.
-    let statement = match source.block.stmts.as_slice() {
-        [stmt] => stmt,
-        [] => {
-            return Err(syn::Error::new(
-                source.block.span(),
-                "expected at least one statement in block",
-            ))
-        }
-
-        // TODO: this is a really dumb restriction.
-        [..] => {
-            return Err(syn::Error::new(
-                source.block.span(),
-                "expected exactly one statement in function body",
-            ))
-        }
-    };
-
-    // Make sure that statement is an expression.
-    let expr: syn::Expr = match statement {
-        syn::Stmt::Expr(expr, _) => expr.clone(),
-        _ => {
-            return Err(syn::Error::new(
-                statement.span(),
-                "expected statement to be an expression",
-            ))
-        }
-    };
-
-    // Parse binary addition to start out.
-    let body = match expr {
-        // Binary addition
-        syn::Expr::Binary(syn::ExprBinary {
-            left,
-            right,
-            op: syn::BinOp::Add(_),
-            ..
-        }) => {
-            let lhs = expr_as_v(&left)?;
-            let rhs = expr_as_v(&right)?;
-            ast::Expr::Apply {
-                func: "plus".into(),
-                args: vec![lhs, rhs],
-            }
-        }
-        _ => panic!("unsupported expression"),
-    };
-
-    Ok(ast::Definition {
-        name,
-        args,
-        ret,
-        body,
-    })
-}
-
-fn expr_as_v(source: &syn::Expr) -> syn::Result<ast::Expr> {
-    match source {
-        // Match integer literals.
-        syn::Expr::Lit(syn::ExprLit {
-            lit: syn::Lit::Int(int),
-            ..
-        }) => Ok(ast::Expr::Nat(int.base10_parse().unwrap())),
-
-        // Match boolean literals.
-        syn::Expr::Lit(syn::ExprLit {
-            lit: syn::Lit::Bool(boolean),
-            ..
-        }) => Ok(ast::Expr::Bool(boolean.value)),
-
-        // Match variables.
-        syn::Expr::Path(syn::ExprPath {
-            path: syn::Path { segments, .. },
-            ..
-        }) => match segments.iter().collect::<Vec<_>>().as_slice() {
-            [segment] => {
-                let ident = &segment.ident;
-                Ok(ast::Expr::Var(ident.to_string()))
-            }
-            _ => Err(syn::Error::new(
-                segments.first().unwrap().ident.span(),
-                "expected a single path segment",
-            )),
-        },
-
-        _ => Err(syn::Error::new(
-            source.span(),
-            "expected an integer literal, boolean literal, or a variable",
-        )),
-    }
-}
-
-fn type_as_v(source: &syn::Type) -> syn::Result<ast::Ty> {
-    match source {
-        syn::Type::Path(ty) => {
-            let segments_str = ty
-                .path
-                .segments
-                .iter()
-                .map(|s| s.ident.to_string())
-                .collect::<Vec<_>>();
-            let segments_refs = segments_str.iter().map(|s| s.as_str()).collect::<Vec<_>>();
-
-            match segments_refs[..] {
-                ["u64"] | ["std", "u64"] => Ok(ast::Ty::Nat),
-                ["bool"] | ["std", "bool"] => Ok(ast::Ty::Nat),
-                _ => Err(syn::Error::new(ty.span(), "unsupported type")),
-            }
-        }
-        _ => Err(syn::Error::new(
-            source.span(),
-            "expected a path type (e.g. `std::u64` or `bool`)",
-        )),
-    }
 }

--- a/roq_derive/src/lib.rs
+++ b/roq_derive/src/lib.rs
@@ -16,7 +16,7 @@ pub fn definition(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     // Convert the function to a Coq `Definition` AST node.
-    let definition = match func::fn_as_definition(&input) {
+    let definition = match func::func_as_ast(&input) {
         Ok(definition) => definition,
         Err(err) => return TokenStream::from(err.to_compile_error()),
     };

--- a/roq_derive/src/ty.rs
+++ b/roq_derive/src/ty.rs
@@ -1,0 +1,26 @@
+use roq_core::ast;
+use syn::spanned::Spanned;
+
+pub fn type_as_v(source: &syn::Type) -> syn::Result<ast::Ty> {
+    match source {
+        syn::Type::Path(ty) => {
+            let segments_str = ty
+                .path
+                .segments
+                .iter()
+                .map(|s| s.ident.to_string())
+                .collect::<Vec<_>>();
+            let segments_refs = segments_str.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+
+            match segments_refs[..] {
+                ["u64"] | ["std", "u64"] => Ok(ast::Ty::Nat),
+                ["bool"] | ["std", "bool"] => Ok(ast::Ty::Nat),
+                _ => Err(syn::Error::new(ty.span(), "unsupported type")),
+            }
+        }
+        _ => Err(syn::Error::new(
+            source.span(),
+            "expected a path type (e.g. `std::u64` or `bool`)",
+        )),
+    }
+}

--- a/roq_derive/src/ty.rs
+++ b/roq_derive/src/ty.rs
@@ -1,7 +1,7 @@
 use roq_core::ast;
 use syn::spanned::Spanned;
 
-pub fn type_as_v(source: &syn::Type) -> syn::Result<ast::Ty> {
+pub fn type_as_ast(source: &syn::Type) -> syn::Result<ast::Ty> {
     match source {
         syn::Type::Path(ty) => {
             let segments_str = ty
@@ -22,5 +22,51 @@ pub fn type_as_v(source: &syn::Type) -> syn::Result<ast::Ty> {
             source.span(),
             "expected a path type (e.g. `std::u64` or `bool`)",
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_snapshot;
+
+    fn parse(input: &str) -> syn::Type {
+        syn::parse_str(input).expect("Failed to parse source code")
+    }
+
+    fn test_as_ty(input: &str) -> ast::Ty {
+        type_as_ast(&parse(input)).expect("Failed to convert to type")
+    }
+
+    #[test]
+    fn test_u64() {
+        assert_snapshot!(
+            test_as_ty("u64"),
+            @"nat"
+        );
+    }
+
+    #[test]
+    fn test_std_u64() {
+        assert_snapshot!(
+            test_as_ty("std::u64"),
+            @"nat"
+        );
+    }
+
+    #[test]
+    fn test_bool() {
+        assert_snapshot!(
+            test_as_ty("bool"),
+            @"nat"
+        );
+    }
+
+    #[test]
+    fn test_std_bool() {
+        assert_snapshot!(
+            test_as_ty("std::bool"),
+            @"nat"
+        );
     }
 }


### PR DESCRIPTION
- **chore: Restructure to add roq_core and roq 'derive' feature**
- **chore: Split parser into separate modules**
- **roq_derive: add snapshot tests**
